### PR TITLE
Add symfony constrains for v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,9 @@
         "adrienrn/php-mimetyper": "^0.2",
         "goetas-webservices/xsd2php-runtime": "^0.2.13",
         "ext-simplexml": "*",
-        "symfony/validator": "^5|^6",
-        "symfony/intl": "^5|^6",
-        "symfony/yaml": "^5|^6",
+        "symfony/validator": "^5|^6|^7",
+        "symfony/intl": "^5|^6|^7",
+        "symfony/yaml": "^5|^6|^7",
         "horstoeko/stringmanagement": "^1"
     },
     "require-dev": {


### PR DESCRIPTION
I have added the v7 constraints to make it compatible with the horstoeko/zugferd package, which does not support UBL syntax.

I've tested it running the PHPUnit tests, what was successful.